### PR TITLE
Returnerer exit-koden som er returnert fra build-scriptet slik at actionen da også eventuelt kan feile.

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -2,7 +2,7 @@
 
 if [[ $INPUT_USE_BUILD_SCRIPT == "true" && -f $INPUT_BUILD_SCRIPT_NAME ]]; then
   ./$INPUT_BUILD_SCRIPT_NAME
-  exit 0
+  exit $?
 fi
 
 if [[ $INPUT_SKIP_TESTS = "true" ]]; then


### PR DESCRIPTION
Slik det står nå feiler ikke actionen selv om build-scriptet feiler.