### PR TITLE
Java8 compat add Python

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,6 +2,6 @@ FROM alpine
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN apk add --no-cache maven gradle bash npm git python3 py3-pip
+RUN apk add --no-cache maven gradle bash npm git python3 py3-pip make
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,6 +2,6 @@ FROM alpine
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN apk add --no-cache maven gradle bash npm git
+RUN apk add --no-cache maven gradle bash npm git python3 py3-pip
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Installerer Python og make. Plutselig nødvendig for å få bl.a. saksoversikt til å bygge. 